### PR TITLE
iwinfo: fix build error

### DIFF
--- a/recipes-core/iwinfo/iwinfo_git.bb
+++ b/recipes-core/iwinfo/iwinfo_git.bb
@@ -21,7 +21,7 @@ FILES_${PN}-dev = "/usr/include /usr/lib/libiwinfo.so"
 FILES_libiwinfo = "/usr/lib/libiwinfo.so.0.0 /usr/lib/libiwinfo.so.0"
 
 do_compile () {
-	oe_runmake compile
+	oe_runmake 'FPIC=-fPIC' compile
 }
 
 do_install () {


### PR DESCRIPTION
The error:
iwinfo_utils.o: relocation R_ARM_MOVW_ABS_NC against `a local symbol' can not be used when making a shared object; recompile with -fPIC

Observed while building for iMX6 with FSL and TS layers (github.com/Freescale, github.com/embeddedarm), MACHINE=ts4900-solo.
