### PR TITLE
juci_git.bb: disable parallel make

### DIFF
--- a/recipes-juci/juci/juci_git.bb
+++ b/recipes-juci/juci/juci_git.bb
@@ -10,6 +10,8 @@ B = "${S}"
 
 PR="r1"
 
+PARALLEL_MAKE = ""
+
 export CONFIG_PACKAGE_juci-ubus-core = "y"
 
 DEPENDS = "libuv-lua"


### PR DESCRIPTION
Otherwise, the build usually fails, mostly with the following error:
| /bin/sh: bin/www/js/01-juci.js: No such file or directory
