### PR TITLE
luajit.bbappend: add dependency on ldconfig-native

### DIFF
--- a/recipes-core/luajit/luajit_%.bbappend
+++ b/recipes-core/luajit/luajit_%.bbappend
@@ -1,3 +1,5 @@
+DEPENDS += "ldconfig-native"
+
 EXTRA_OEMAKE = 'CROSS=${HOST_PREFIX} \
                 TARGET_CFLAGS="${TOOLCHAIN_OPTIONS} ${HOST_CC_ARCH}" \
                 TARGET_LDFLAGS="${TOOLCHAIN_OPTIONS} ${TUNE_CCARGS}" \


### PR DESCRIPTION
Without a working ldconfig, luajit package will build without errors but will be missing .so symlinks (see e.g. https://lists.gnu.org/archive/html/guix-devel/2015-02/msg00086.html ). This will happen inconsistently, depending on bitbake task execution order. When it happens, packages trying to link against libluajit-5.1,so will fail.