### PR TITLE
Fix build errors & warnings on krogoth under Ubuntu 16.04

### DIFF
--- a/recipes-core/libubox/libubox_git.bb
+++ b/recipes-core/libubox/libubox_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Basic utility library"
 HOMEPAGE = "http://wiki.openwrt.org/doc/uci"
-LICENSE = "ISC BSD-3c"
+LICENSE = "ISC"
 LIC_FILES_CHKSUM = "file://uloop.c;beginline=4;endline=17;md5=ae045d075c7d6dde096232b6130a5202"
 
 SRC_URI = "git://git.openwrt.org/project/libubox.git;protocol=git;branch=master"

--- a/recipes-core/luajit/luajit_%.bbappend
+++ b/recipes-core/luajit/luajit_%.bbappend
@@ -13,9 +13,7 @@ EXTRA_OEMAKE_class-native_append = ' \
 
 do_install_append () {
 	mkdir -p ${D}/usr/bin
-	pushd ${D}/usr/bin
-	ln -s luajit lua
-	popd 
+	ln -s luajit ${D}/usr/bin/lua
 }
 
 do_install_class-native () {

--- a/recipes-juci/juci/files/fix_host_uid_leak.patch
+++ b/recipes-juci/juci/files/fix_host_uid_leak.patch
@@ -1,0 +1,33 @@
+This patch fixes host UID contamination.
+
+diff --git a/Makefile b/Makefile
+index 7d81490..fab0e36 100644
+--- a/Makefile
++++ b/Makefile
+@@ -19,7 +19,7 @@ CSS_DIR:=$(BIN)/www/css
+ TMP_DIR:=tmp
+ TARGETS:=
+ PHONY:=debug release clean prepare node_modules 
+-CP:=cp -Rp 
++CP:=cp -R 
+ Q:=@
+ INSTALL_DIR:=mkdir -p
+ 
+@@ -204,7 +204,7 @@ install:
+ 	$(INSTALL_DIR) $(BIN)/usr/bin/
+ 	@cp juci.config.example $(BIN)/usr/share/juci/
+ 	@cp juci-update $(BIN)/usr/bin/
+-	@cp -Rp $(BIN)/* $(DESTDIR)
++	@$(CP) $(BIN)/* $(DESTDIR)
+ 
+ .PHONY: $(PHONY) $(UBUS_MODS) 
+ 
+@@ -213,7 +213,7 @@ $(UBUS_MODS):
+ 	@echo "CFLAGS: $(CFLAGS)"
+ 	@make -i -C $@ clean
+ 	@make -C $@ 
+-	@cp -Rp $@/build/* $(BIN)/
++	@$(CP) $@/build/* $(BIN)/
+ 	
+ clean: 
+ 	rm -rf ./bin ./tmp

--- a/recipes-juci/juci/juci_git.bb
+++ b/recipes-juci/juci/juci_git.bb
@@ -7,6 +7,8 @@ SRCREV = "9d07c63b2d6f7eee17f6c6dfc3f783324599bfd8"
 
 SRC_URI += "file://40-juci-openwrt-config"
 SRC_URI += "file://user-admin.acl"
+SRC_URI += "file://fix_host_uid_leak.patch"
+
 S = "${WORKDIR}/git"
 B = "${S}"
 
@@ -17,16 +19,6 @@ DEPENDS = "lighttpd luajit orange-rpcd"
 RDEPENDS_${PN} = "lighttpd luajit orange-rpcd"
 
 FILES_${PN} += " /usr/lib/* /usr/share/* /etc/* /sbin/* /www/* "
-
-do_configure_prepend () {
-	pushd ${B}
-	#./bootstrap.sh
-	popd
-}
-
-do_install_append () {
-	:
-}
 
 do_compile () {
 	oe_runmake clean

--- a/recipes-juci/lighttpd/lighttpd_%.bbappend
+++ b/recipes-juci/lighttpd/lighttpd_%.bbappend
@@ -32,9 +32,9 @@ LDFLAGS_append = " -lpcre "
 RDEPENDS_${PN} = ""
 
 do_install () {
-	DESTDIR=${D} oe_runmake install
+	oe_runmake install DESTDIR=${D}
 	install -d ${D}/etc
-	cp -a ${WORKDIR}/etc/* ${D}/etc/
+	cp -r ${WORKDIR}/etc/* ${D}/etc/
 	install -d ${D}/etc/init.d
 	install -m 750 ${WORKDIR}/lighttpd.init ${D}/etc/init.d/lighttpd
 	return 0;


### PR DESCRIPTION
* libubox_git.bb: LICENSE (changed to match
https://github.com/openwrt/openwrt/blob/master/package/libs/libubox/Makefile).

* luajit_%.bbappend: removed unnecessary bashism (pushd).

* juci_git.bb: removed unnecessary bashism (pushd);
patch to fix host uid contamination (cp -p)

* lighttpd_%.bbappend: fixed DESTDIR not propagating into Makefile;
fixed host uid contamination (cp -a).